### PR TITLE
Implement Lefthook (alternative to Husky)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-commit:
+  parallel: true
+  commands:
+    format:
+      glob: '*.{js,ts,tsx,md,json}'
+      run: pnpm format

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "5.2.2"
   },
   "devDependencies": {
+    "lefthook": "1.4.11",
     "prettier": "3.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ dependencies:
     version: 5.2.2
 
 devDependencies:
+  lefthook:
+    specifier: 1.4.11
+    version: 1.4.11
   prettier:
     specifier: 3.0.3
     version: 3.0.3
@@ -1505,6 +1508,85 @@ packages:
     dependencies:
       language-subtag-registry: 0.3.22
     dev: false
+
+  /lefthook-darwin-arm64@1.4.11:
+    resolution: {integrity: sha512-XyF532yTp+UoqN22QNHk1TxnbUaGPBkIlQ1N4GlYRl3GJiBeiCVEoGzmibXcWnR0OIN+nAhRjoNkaj3JocPvYQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-darwin-x64@1.4.11:
+    resolution: {integrity: sha512-OGyCwRqCLsy14/eSNIC3QiZvy+q9UdwsJUn/iVXYegFwYIhTMpUeyLspoXNrYoPZmDs4OB6Nd5n5JHcrSuOVvQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-freebsd-arm64@1.4.11:
+    resolution: {integrity: sha512-3JGAyuf8PmGWkNUL8z1G5PQKrLaiJGOeXXeCgCIJG7AevITyrEljYhP2qxaRSTyoBnwavBPeNYQXt+AG4Smthw==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-freebsd-x64@1.4.11:
+    resolution: {integrity: sha512-8J7lZOwbxarFk3mivQTh5kXf0FhQSydCiB8KUFy/j2RAIYtpZdGOHEBtLw6aGAFzzhBfo0zPkVZ2ouhisLNelw==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-linux-arm64@1.4.11:
+    resolution: {integrity: sha512-H1ArFa3K54V3lQ0xV2cZKiNAjmzJA/xi2kuD8ERV96gwYq4vpGzY4x/wJL77UVKdw7Ofqy/FS8kEn3uCT2JvOA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-linux-x64@1.4.11:
+    resolution: {integrity: sha512-KtDmtnsg6kjNufx97N47BdP2ZFgHBHQb+rWwR2RagzNY3exYQM9iH+d0BeY0RuIUL+QwUCkpkVeEYgTrMcN3+A==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-windows-arm64@1.4.11:
+    resolution: {integrity: sha512-9GbPflx7F70jqHy8bEVxthmlmUUb+2NnzPU/Kk10DpWuZLXLOXWK7yGqIQogAnqwhlo4bSrWaWGfRULtAsQ2DQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-windows-x64@1.4.11:
+    resolution: {integrity: sha512-UI3EiY4OXplWx3WTddOyakazs5uD8QD5XIawRxNamZ4iJe/paLzBWbWZ6Xix9kpE06tmE2z9DfLT3A/08l23Gg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook@1.4.11:
+    resolution: {integrity: sha512-pz1578a2zoiUHZRt3x3fANgx8W9nRex37Xt96NqU4YPXNvwNAZucsEchSjYzkxZqV/UK/IAU6R+IQGBeuFx7Dg==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.4.11
+      lefthook-darwin-x64: 1.4.11
+      lefthook-freebsd-arm64: 1.4.11
+      lefthook-freebsd-x64: 1.4.11
+      lefthook-linux-arm64: 1.4.11
+      lefthook-linux-x64: 1.4.11
+      lefthook-windows-arm64: 1.4.11
+      lefthook-windows-x64: 1.4.11
+    dev: true
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}


### PR DESCRIPTION
Implements [lefthook](https://github.com/evilmartians/lefthook) which is an alternative to [husky](https://github.com/typicode/husky) for managing git hooks.

Lefthook [spruiks itself](https://github.com/evilmartians/lefthook/wiki/Comparison-with-other-solutions) as being faster and simpler than husky and other alternatives.